### PR TITLE
Enable CORS support

### DIFF
--- a/head-checker/src/index.js
+++ b/head-checker/src/index.js
@@ -2,11 +2,24 @@ export default {
   async fetch(request, env, ctx) {
     const { searchParams } = new URL(request.url);
 
+    const corsHeaders = {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    };
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+
     const url = searchParams.get("url");
     if (!url) {
       return new Response(
         JSON.stringify({ error: "Missing 'url' parameter" }),
-        { status: 400, headers: { "content-type": "application/json" } }
+        {
+          status: 400,
+          headers: { "content-type": "application/json", ...corsHeaders },
+        }
       );
     }
 
@@ -14,12 +27,17 @@ export default {
       const headResp = await fetch(url, { method: "HEAD", redirect: "manual" });
       return new Response(
         JSON.stringify({ status: headResp.status }),
-        { headers: { "content-type": "application/json" } }
+        {
+          headers: { "content-type": "application/json", ...corsHeaders },
+        }
       );
     } catch (e) {
       return new Response(
         JSON.stringify({ error: "Fetch failed", details: e.message }),
-        { status: 500, headers: { "content-type": "application/json" } }
+        {
+          status: 500,
+          headers: { "content-type": "application/json", ...corsHeaders },
+        }
       );
     }
   },

--- a/head-checker/test/index.spec.js
+++ b/head-checker/test/index.spec.js
@@ -2,19 +2,23 @@ import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloud
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('head-checker worker', () => {
+  it('returns 400 when url parameter is missing (unit)', async () => {
+    const request = new Request('http://example.com');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Missing 'url' parameter" });
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+  it('handles OPTIONS request for CORS preflight', async () => {
+    const request = new Request('http://example.com', { method: 'OPTIONS' });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
 });


### PR DESCRIPTION
## Summary
- support CORS requests in the Worker
- test missing URL and preflight behaviour

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a00f27888320a5e058ea52cd156c